### PR TITLE
A11y fixes for email template

### DIFF
--- a/email_template.html
+++ b/email_template.html
@@ -243,15 +243,15 @@ h3 { font-size: 15pt; }
 	</style>
 </head>
 <body bgcolor="#ffffff">
-<table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" width="100%">
+<table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" width="100%" role="presentation">
 	<tbody>
 		<tr>
 			<td align="center" id="bodyCell" valign="top">
-			<table border="0" cellpadding="0" cellspacing="0" id="templateContainer" width="100%">
+			<table border="0" cellpadding="0" cellspacing="0" id="templateContainer" width="100%" role="presentation">
 				<tbody>
 					<tr>
 						<td align="center" valign="top">
-						<table bgcolor="#00274c" border="0" cellpadding="0" cellspacing="0" id="templateHeader" width="100%">
+						<table bgcolor="#00274c" border="0" cellpadding="0" cellspacing="0" id="templateHeader" width="100%" role="presentation">
 							<tbody>
 								<tr>
 									<td class="headerContainer" valign="top">
@@ -272,7 +272,7 @@ h3 { font-size: 15pt; }
 					</tr>
 					<tr>
 						<td align="center" valign="top">
-						<table bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="30" id="templateBody" width="100%">
+						<table bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="30" id="templateBody" width="100%" role="presentation">
 							<tbody>
 								<tr>
 									<td valign="top">

--- a/email_template.html
+++ b/email_template.html
@@ -357,7 +357,7 @@ h3 { font-size: 15pt; }
     <thead>
       <tr>
         {% for column in traffic_table_columns %}
-        <th class="rt-{{column['name']}}">{{column['label']}}</th>
+        <th class="rt-{{column['name']}}" scope="col">{{column['label']}}</th>
         {% endfor %}
       </tr>
     </thead>
@@ -370,7 +370,7 @@ h3 { font-size: 15pt; }
     <tbody>
       {% for row in traffic_table_rows %}
       <tr>
-        <th class="rt-month">{{traffic_table_rows[row]['month']}}</th>
+        <th class="rt-month" scope="row">{{traffic_table_rows[row]['month']}}</th>
         {% for column in traffic_table_columns[1:] %}
         <td class="rt-{{column['name']}}">
           <div class="rt-data-header rt-{{column['name']}}">{{column['label']}}</div>
@@ -390,7 +390,7 @@ h3 { font-size: 15pt; }
       <thead>
         <tr>
           {% for column in cost_table_columns %}
-          <th class="rt-cost-{{column['name']}}">{{column['label']}}</th>
+          <th class="rt-cost-{{column['name']}}" scope="col">{{column['label']}}</th>
           {% endfor %}
         </tr>
       </thead>
@@ -402,7 +402,7 @@ h3 { font-size: 15pt; }
       <tbody>
         {% for row in cost_table_rows %}
         <tr>
-          <th class="rt-cost-plan">{{cost_table_rows[row]['plan']}}</th>
+          <th class="rt-cost-plan" scope="row">{{cost_table_rows[row]['plan']}}</th>
           {% for column in cost_table_columns[1:] %}
           <td class="rt-cost-{{column['name']}}">
             <div class="rt-data-header rt-cost-{{column['name']}}">{{column['label']}}</div>


### PR DESCRIPTION
Made a few quick fixes for the email template to address table accessibility.

  * Add `role="presentation"` to the tables used for layout
  * Add `scope="row|col"` to the headings to indicate what they are headings for in tables with data